### PR TITLE
Instances for MFunctor

### DIFF
--- a/Control/Monad/Resumption.hs
+++ b/Control/Monad/Resumption.hs
@@ -7,6 +7,7 @@ import Control.Monad
 import Control.Monad.Trans
 import Control.Applicative
 import Control.Monad.IO.Class
+import Control.Monad.Morph
 
 -- | Resumption monad transformer.
 newtype ResT m a = ResT { deResT :: m (Either a (ResT m a)) }
@@ -45,6 +46,9 @@ instance Monad m => Applicative (ResT m) where
                               
 instance MonadIO m => MonadIO (ResT m) where
   liftIO = lift . liftIO
+
+instance MFunctor ResT where
+  hoist f = ResT . f . liftM (fmap (hoist f)) . deResT
 
 -- | Waits until the next tick.
 tick :: Monad m => ResT m ()

--- a/Control/Monad/Resumption/Reactive.hs
+++ b/Control/Monad/Resumption/Reactive.hs
@@ -8,6 +8,7 @@ import Control.Monad
 import Control.Monad.Trans
 import Control.Applicative
 import Control.Monad.IO.Class
+import Control.Monad.Morph
 import Control.Monad.Resumption
 
 -- | Reactive resumption monad transformer.
@@ -36,6 +37,9 @@ instance Monad m => Applicative (ReacT input output m) where
 
 instance MonadIO m => MonadIO (ReacT input output m) where
   liftIO = lift . liftIO
+
+instance MFunctor (ReacT i o) where
+  hoist f = ReacT . f . liftM (fmap (fmap (fmap (hoist f)))) . deReacT
 
 -- | Outputs its argument, then waits for the next input and returns it.
 signal :: Monad m => output -> ReacT input output m input

--- a/monad-resumption.cabal
+++ b/monad-resumption.cabal
@@ -26,6 +26,6 @@ library
     Control.Monad.Resumption.Connectors
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.6 && <= 4.8, transformers, mtl
+  build-depends:       base >=4.6 && <= 4.8, transformers, mtl, mmorph
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
The mmorph library is a very light dependency and allows for some interesting uses of a library like monad-resumption.  Here are some instances if you think it's appropriate.
